### PR TITLE
Added the tensorflow pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2560,6 +2560,10 @@ python-telegram-bot:
   ubuntu:
     pip:
       packages: [python-telegram-bot]
+python-tensorflow:
+  ubuntu:
+    pip:
+      packages: [tensorflow]
 python-termcolor:
   debian:
     jessie: [python-termcolor]


### PR DESCRIPTION
https://pypi.python.org/pypi/tensorflow/0.12.1.

Google's framework for neural networks. This only provides the python interface; the C++ API is trickier to get. But this is the first step to get at least the python dependency satisfiable via rosdep.